### PR TITLE
제품 상세페이지 - 토핑, 음료, 사이드 수량 2개 이상시 합계 반영안되는 현상 해결 외 2건

### DIFF
--- a/src/main/java/com/damino/web/user/goods/GoodsListController.java
+++ b/src/main/java/com/damino/web/user/goods/GoodsListController.java
@@ -215,13 +215,15 @@ public class GoodsListController {
 		}
 	}
 
+	@SuppressWarnings("null")
 	@RequestMapping(value = "insert_basket.do", method = RequestMethod.POST)
 	@ResponseBody
 	public String go_InsertBasket(@RequestBody Map<String, Object> param, HttpServletRequest request, @ModelAttribute UserBasketVO vo, HttpSession session) {
 		
-		int gubunDB = 0;// DB 삽입 정보 구별을 위한 변수.  값이 증가되지 않아 증가된 값을 받아올 예정
-		String gubun = ""; //세션 정보 확인을 구한 변수
+		int gubunDB = 1;// DB 삽입 정보 구별을 위한 변수.  값이 증가되지 않아 증가된 값을 받아올 예정
+		String gubun = (String)param.get("gubun"); //세션 정보 확인을 구한 변수
 		
+		gubunDB++;
 	//--------------피자---------------------------
 		String userId = (String) param.get("userId");
 		int p_price = (Integer) param.get("pizzaPrice");
@@ -248,21 +250,24 @@ public class GoodsListController {
 		String t_names = (String)param.get("toppingName");
 		String t_counts = (String)param.get("toppingCount");
 		
-		String t_priceArr[] = t_prices.split(",");
-		String t_nameArr[] = t_names.split(",");
-		String t_countArr[] = t_counts.split(",");
 		
-		System.out.println("t_names : " + t_names);
-		
-		for(int i=0; i<t_nameArr.length; i++) {
-			vo.setUserid(userId);
-			vo.setT_name(t_nameArr[i]);
-			vo.setT_price(Integer.parseInt(t_priceArr[i]));
-			//vo.setT_image(t_image);
-			vo.setT_count(Integer.parseInt(t_countArr[i]));
-			vo.setGubun(gubunDB);
+			String t_priceArr[] = t_prices.split(",");
+			String t_nameArr[] = t_names.split(",");
+			String t_countArr[] = t_counts.split(",");
 			
-			goodsListService.insertToppingBasket(vo);
+		if(t_nameArr.length > 1) {		
+			System.out.println("t_names : " + t_names);
+			
+			for(int i=0; i<t_nameArr.length; i++) {
+				vo.setUserid(userId);
+				vo.setT_name(t_nameArr[i]);
+				vo.setT_price(Integer.parseInt(t_priceArr[i]));
+				//vo.setT_image(t_image);
+				vo.setT_count(Integer.parseInt(t_countArr[i]));
+				vo.setGubun(gubunDB);
+				
+				goodsListService.insertToppingBasket(vo);
+			}
 		}
 		
 	//--------------사이드---------------------------------
@@ -270,29 +275,40 @@ public class GoodsListController {
 		String s_names = (String)param.get("sideName");
 		String s_counts =  (String)param.get("sideCount");
 		
-		String s_priceArr[] = s_prices.split(",");
-		String s_nameArr[] = s_names.split(",");
-		String s_countArr[] = s_counts.split(",");
+		System.out.println("s_names : " + s_names);
 		
-		for(int i=0; i<s_nameArr.length; i++) {
-			vo.setUserid(userId);
-			vo.setS_name(s_nameArr[i]);
-			vo.setS_price(Integer.parseInt(s_priceArr[i]));
-			//vo.setT_image(t_image);
-			vo.setS_count(Integer.parseInt(s_countArr[i]));
-			vo.setGubun(gubunDB);
 			
-			goodsListService.insertSideBasket(vo);
+			String s_priceArr[] = s_prices.split(",");
+			String s_nameArr[] = s_names.split(",");
+			String s_countArr[] = s_counts.split(",");
+		System.out.println("s_nameArr : " + s_nameArr.length);	
+		if(s_nameArr.length > 1) {	
+				System.out.println("테스트");
+			for(int i=0; i<s_nameArr.length; i++) {
+				vo.setUserid(userId);
+				vo.setS_name(s_nameArr[i]);
+				vo.setS_price(Integer.parseInt(s_priceArr[i]));
+				//vo.setT_image(t_image);
+				vo.setS_count(Integer.parseInt(s_countArr[i]));
+				vo.setGubun(gubunDB);
+				
+				goodsListService.insertSideBasket(vo);
+			}
 		}
+		
 	// ------------음료 및 기타-------------------------
 		String d_prices = (String) param.get("etcPrice");
 		String d_names = (String) param.get("etcName");
 		String d_counts = (String) param.get("etcCount");
+		System.out.println("d_names : " + d_names);
+		
 		
 		String d_priceArr[] = d_prices.split(",");
 		String d_nameArr[] = d_names.split(",");
 		String d_countArr[] = d_counts.split(",");
 		
+		if(d_nameArr.length > 1) {	
+			System.out.println("테스트2");
 		for(int i=0; i<d_nameArr.length; i++) {
 			vo.setUserid(userId);
 			vo.setD_name(d_nameArr[i]);
@@ -302,9 +318,8 @@ public class GoodsListController {
 			vo.setGubun(gubunDB);
 			
 			goodsListService.insertEtcBasket(vo);
-		}
-		
-		
+			}
+		}		
 		
 		if(gubun != null) {
 			return "success";

--- a/src/main/java/com/damino/web/user/goods/GoodsListService.java
+++ b/src/main/java/com/damino/web/user/goods/GoodsListService.java
@@ -14,8 +14,8 @@ public interface GoodsListService {
 
 //------------------사용자 선택 --------------------
 	//사용자 선택 -피자 메뉴 불러오기(2번째는 이름만 비교)
-		public GoodsPizzaVO getUserPizzaGoods(GoodsPizzaVO vo);
-		public GoodsPizzaVO getUserPizza(GoodsPizzaVO vo);
+	public GoodsPizzaVO getUserPizzaGoods(GoodsPizzaVO vo);
+	public GoodsPizzaVO getUserPizza(GoodsPizzaVO vo);
 	//사용자 선택 - 사이드디시 메뉴 불러오기
 	public GoodsSideVO getUserSideGoods(GoodsSideVO vo);
 	//사용자 선택 - 토핑 메뉴 불러오기

--- a/src/main/webapp/WEB-INF/views/daminoUserView/basket/basket_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/daminoUserView/basket/basket_detail.jsp
@@ -812,6 +812,7 @@ function sideDelete(idx) {
 										<c:forEach var="pizza" items="${basketList}" varStatus="status">
 											<div class="hidden-info">
 											<input type="hidden" id="userid" value="${userid}" />	
+											<input type="hidden" id="gubun" value="${pizza.gubun}"/>
 											</div>
 											<c:if test="${pizza.p_name != null }">
 												<li class="row" id="row${status.index}">
@@ -832,6 +833,7 @@ function sideDelete(idx) {
 												
 													<div class="prd-option"  id="prd-option${status.index }"  style="">
 													<c:forEach var="toppingList" items="${toppingList}" varStatus="status">
+													<c:if test="${pizza.gubun eq toppingList.gubun}">
 														<ul>
 														<li>
 														<span>${toppingList.t_name}(<fmt:formatNumber value="${toppingList.t_price}" pattern="#,###" />원)x${toppingList.t_count}
@@ -848,12 +850,9 @@ function sideDelete(idx) {
 															id="delPizza" class="btn-close"> <span class="hidden">삭제</span> 
 													</a>
 													<input type="hidden" id="t_name" value="${topping.t_name}"/>--%>
+													</c:if>
 													</c:forEach> 
 													</div>
-												
-													<%-- <a href="javascript:toppingDelete(${pizza.seq});"
-															id="delPizza" class="btn-close"> <span class="hidden">삭제</span>
-													</a> --%>
 													<div class="prd-quantity">
 														<div class="quantity-box v2">
 															<a href="javascript:void(0);"

--- a/src/main/webapp/WEB-INF/views/daminoUserView/goods/detail_goods.jsp
+++ b/src/main/webapp/WEB-INF/views/daminoUserView/goods/detail_goods.jsp
@@ -282,18 +282,18 @@ function sum(){
 	
 	//토핑 합계 가격 배열 정보를 Number로 변환하여 전역변수 totalToppingSum에 저장
 	for(var i=0; i<toppingNameArr.length; i++){											
-		totalToppingSum += Number(toppingSumArr[i]);
+		totalToppingSum += Number(toppingSumArr[i]) * Number(toppingCntArr[i]);
 		//selectToppingName += toppingNameArr[i];
 	}					
  
 	//음료 합계 가격 배열 정보를 Number로 변환하여 전역변수 totalEtcSum에 저장
 	for(var i=0; i<etcSumArr.length; i++){											
-		totalEtcSum += Number(etcSumArr[i]);
+		totalEtcSum += Number(etcSumArr[i]) * Number(etcCntArr[i]);
 	}
 	
 	//사이드디시 합계 가격 배열 정보를 Number로 변환하여 전역변수 totalSideSum에 저장
 	for(var i=0; i<sideSumArr.length; i++){											
-		totalSideSum += Number(sideSumArr[i]);
+		totalSideSum += Number(sideSumArr[i]) * Number(sideCntArr[i]);
 	}
 	
 	if(typeof price == "undefined"){
@@ -335,7 +335,10 @@ function sum(){
 	etcSum += Number($('.etcSum').val());
 	//console.log("합계금액 2 : " + Number(pizzaAmt+doughPrice));
 	$(".total-price_sum").text(Number(pizzaAmt+ Number(doughPrice) + totalToppingSum + totalEtcSum + totalSideSum) + "원");	
-		
+	
+	var s_total = $(".total-price_sum").text();
+	s_total = s_total.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+	$(".total-price_sum").html(s_total);	
 	
 }
 
@@ -402,6 +405,10 @@ function totalDoughValue(){
 	}
    $(".total-count").text((Number($("#pizzaSetNum").val())));
    $(".total-price_sum").text(Number(pizzaAmt)+Number(doughPrice) + "원");
+   
+   var s_total = $(".total-price_sum").text();
+	s_total = s_total.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+	$(".total-price_sum").html(s_total);
    
    	sum();
 }


### PR DESCRIPTION
제품 상세페이지
1. 토핑, 음료, 사이드 수량 2개 이상시 합계 반영안되는 현상 해결
2. 합계금액 천단위 구분 쉼표 적용

장바구니 - 구분값과 일치하는 토핑정보만 피자에 나오도록 반영